### PR TITLE
:bug: accept undefined on currentPage/nextPage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,9 +78,11 @@ const parseToInt = (value, defaultValue) => {
  * @return {Object} pagination info which contains pageNumber and pageSize properties.
  */
 const parseParams = (page, options) => {
+  const values = page || {};
+
   return {
-    pageNumber: parseToInt(page.number, 1),
-    pageSize: parseToInt(page.size, options.size)
+    pageNumber: parseToInt(values.number, 1),
+    pageSize: parseToInt(values.size, options.size)
   };
 };
 
@@ -111,7 +113,7 @@ class Pagination {
     cls.pagination = opts;
 
     cls.addScope('paginate', function(params) {
-      const parsed = parseParams((params || {}), this.pagination);
+      const parsed = parseParams(params, this.pagination);
 
       return {
         limit: parsed.pageSize,

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -216,18 +216,38 @@ describe('Pagination', () => {
   });
 
   describe('currentPage', () => {
-    it('should return currentPage', () => {
-      const params = {number: '30', size: '10'};
-      const result = User.currentPage(params);
-      expect(result).to.eql({number: 30, size: 10});
+    describe('when valid params', () => {
+      it('should return currentPage', () => {
+        const params = {number: '30', size: '10'};
+        const result = User.currentPage(params);
+        expect(result).to.eql({number: 30, size: 10});
+      });
+    });
+
+    describe('when params is undefined', () => {
+      it('should return first page as currentPage', () => {
+        const params = undefined;
+        const result = User.currentPage(params);
+        expect(result).to.eql({number: 1, size: 20});
+      });
     });
   });
 
   describe('nextPage', () => {
-    it('should return nextPage object', () => {
-      const params = {number: '2', size: '30'};
-      const result = User.nextPage(params);
-      expect(result).to.eql({number: 3, size: 30});
+    describe('when valid params', () => {
+      it('should return nextPage object', () => {
+        const params = {number: '2', size: '30'};
+        const result = User.nextPage(params);
+        expect(result).to.eql({number: 3, size: 30});
+      });
+    });
+
+    describe('when params is undefined', () => {
+      it('should return second page as nextPage', () => {
+        const params = undefined;
+        const result = User.nextPage(params);
+        expect(result).to.eql({number: 2, size: 20});
+      });
     });
   });
 });


### PR DESCRIPTION
モデルのクラス・メソッドとして追加する`nextPage`/`currentPage`のメソッドで`undefined`を許容するようにしました。

## 内容

以前、paginate scopeは対応したのですが、他メソッドをケアできてなかったため修正してます。